### PR TITLE
Downgrade python to 3.11 to enable cloudflare builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jonathan Leeming <jonathan@leeming.dev>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 typst = "^0.11.1"
 
 


### PR DESCRIPTION
Python 3.12 is too new to be widely supported, so I have downgraded the version to 3.11 which still works fine.